### PR TITLE
fix: Clean up all console noise in Joe interface

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -137,8 +137,7 @@ export default function ChatPanel({
                                                         }}
                                                             onClick={() => {
                                                                 // TODO: Trigger AutoOpenManager or Workspace Service to open the file.
-                                                                // For now, it's just a visual UI improvement. 
-                                                                console.log(`Open file: ${filepath} at lines ${startLine}-${endLine}`);
+                                                                void 0;
                                                             }}
                                                             onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--joe-gold-primary)'; e.currentTarget.style.boxShadow = '0 0 15px rgba(240,193,75,0.15)'; }}
                                                             onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'rgba(240, 193, 75, 0.3)'; e.currentTarget.style.boxShadow = 'none'; }}

--- a/web/src/components/EmbeddedBrowser.tsx
+++ b/web/src/components/EmbeddedBrowser.tsx
@@ -98,8 +98,8 @@ export default function EmbeddedBrowser({
             });
             setCurrentUrl(targetUrl);
             setInputUrl(targetUrl);
-        } catch (e) {
-            console.error('Navigation failed:', e);
+        } catch {
+            // Navigation failed silently
         } finally {
             setIsLoading(false);
         }
@@ -121,8 +121,8 @@ export default function EmbeddedBrowser({
                     actions: [action]
                 })
             });
-        } catch (e) {
-            console.error('Action failed:', e);
+        } catch {
+            // Action failed silently
         } finally {
             setIsLoading(false);
         }

--- a/web/src/components/EmbeddedTerminal.tsx
+++ b/web/src/components/EmbeddedTerminal.tsx
@@ -187,7 +187,7 @@ export default function EmbeddedTerminal({
                 if (fitAddonRef.current && containerRef.current && termRef.current) {
                     // [Wakil 5.1] Block resize during Quiet Mode
                     if (SocketService.isQuietMode()) {
-                            return;
+                        return;
                     }
                     try {
                         const term = termRef.current as any;
@@ -202,8 +202,7 @@ export default function EmbeddedTerminal({
                         try {
                             // Defensive fit
                             fitAddonRef.current.fit();
-                        } catch (e) {
-                            console.debug('[Terminal] Proactive fit error:', e);
+                        } catch {
                             // Fall through to proposeDimensions if fit fails
                         }
 
@@ -222,15 +221,14 @@ export default function EmbeddedTerminal({
                             lastCols = cols;
                             lastRows = rows;
 
-                                SocketService.send({
+                            SocketService.send({
                                 type: 'terminal_resize',
                                 id: terminalId,
                                 cols,
                                 rows
                             });
                         }
-                    } catch (e) {
-                        console.debug('[Terminal] Fit/Resize error:', e);
+                    } catch {
                     }
                 }
             }, 300); // Increased debounce to 300ms for stability
@@ -264,8 +262,7 @@ export default function EmbeddedTerminal({
                 if (termToDispose) {
                     termToDispose.dispose();
                 }
-            } catch (e) {
-                console.debug('[Terminal] Dispose error:', e);
+            } catch {
             }
         };
     }, [terminalId, getTerminalTheme, onReady]);

--- a/web/src/components/EmbeddedTerminal.tsx
+++ b/web/src/components/EmbeddedTerminal.tsx
@@ -163,7 +163,6 @@ export default function EmbeddedTerminal({
             if (!isReady) return;
             // [Wakil 5.2] HARD FREEZE: No input during agent run
             if (SocketService.isQuietMode()) {
-                console.log('[Terminal] Input BLOCKED (Hard Quiet Mode)');
                 return;
             }
             SocketService.send({
@@ -188,8 +187,7 @@ export default function EmbeddedTerminal({
                 if (fitAddonRef.current && containerRef.current && termRef.current) {
                     // [Wakil 5.1] Block resize during Quiet Mode
                     if (SocketService.isQuietMode()) {
-                        console.log('[Terminal] Resize blocked (Quiet Mode)');
-                        return;
+                            return;
                     }
                     try {
                         const term = termRef.current as any;
@@ -224,8 +222,7 @@ export default function EmbeddedTerminal({
                             lastCols = cols;
                             lastRows = rows;
 
-                            console.log(`[Terminal] Resizing: ${cols}x${rows}`);
-                            SocketService.send({
+                                SocketService.send({
                                 type: 'terminal_resize',
                                 id: terminalId,
                                 cols,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -19,7 +19,11 @@ import './i18n';
 
 const shouldIgnoreNoiseError = (val: any) => {
   const s = String(val?.stack || val?.message || val?.filename || val || '');
-  return s.includes('solanaActionsContentScript.js');
+  return s.includes('solanaActionsContentScript.js') ||
+    s.includes('React Router Future Flag Warning') ||
+    s.includes('[Socket Debug]') ||
+    s.includes('[Socket]') ||
+    s.includes('Download the React DevTools');
 };
 
 // Global console.error proxy to filter out extension noise
@@ -148,7 +152,7 @@ createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     {(() => {
       const appTree = (
-        <BrowserRouter>
+        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <Routes>
             <Route path="/" element={<App />}>
               <Route index element={<Suspense fallback={<div className="route-loading">Loading…</div>}><LandingPage /></Suspense>} />

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -22,7 +22,6 @@ const shouldIgnoreNoiseError = (val: any) => {
   return s.includes('solanaActionsContentScript.js') ||
     s.includes('React Router Future Flag Warning') ||
     s.includes('[Socket Debug]') ||
-    s.includes('[Socket]') ||
     s.includes('Download the React DevTools');
 };
 

--- a/web/src/pages/Joe.tsx
+++ b/web/src/pages/Joe.tsx
@@ -333,8 +333,8 @@ export default function Joe() {
                 });
 
                 setMessages(validMessages as Message[]);
-            } catch (e) {
-                console.error('Failed to load messages:', e);
+            } catch {
+                // Silently handle message load failures
             }
         };
 
@@ -363,7 +363,6 @@ export default function Joe() {
             }
 
             // 2. If none, create one
-            console.log('No workspace found, creating default...');
             const newWs: any = await api.post('/workspaces', { name: 'My Workspace' });
             if (newWs && (newWs._id || newWs.id)) {
                 const wsId = newWs._id || newWs.id;
@@ -372,8 +371,8 @@ export default function Joe() {
                 setIsOnboardingOpen(true);
                 return wsId;
             }
-        } catch (e) {
-            console.error('Failed to ensure workspace:', e);
+        } catch {
+            // Silently handle workspace errors
         }
         return null;
     }, []);
@@ -397,8 +396,8 @@ export default function Joe() {
                 role: 'assistant',
                 content: '✨ **مشروع محلي جديد جاهز!**\n\nلقد قمت بإعداد بيئة العمل المحلية بنجاح. يمكنك الآن البدء في بناء تطبيقك، إنشاء ملفات، أو طلب مساعدتي في أي مهمة برمجية.'
             }]);
-        } catch (e) {
-            console.error('Failed to initialize local project:', e);
+        } catch {
+            // Silently handle local project init errors
         }
     }, [workspaceId]);
 
@@ -474,8 +473,8 @@ export default function Joe() {
                         }
                     }
                 }
-            } catch (e) {
-                console.error('Failed to init GitHub:', e);
+            } catch {
+                // GitHub init not available
             }
         };
 
@@ -493,8 +492,8 @@ export default function Joe() {
                 const commits = await githubService.getCommits(activeRepo.fullName.split('/')[0], activeRepo.name);
                 setGhCommits(commits);
             }
-        } catch (e) {
-            console.error('Failed to refresh GitHub:', e);
+        } catch {
+            // GitHub refresh failed silently
         } finally {
             setGhLoading(false);
         }
@@ -506,16 +505,14 @@ export default function Joe() {
 
         // Persist selection
         if (workspaceId) {
-            githubService.setActiveRepo(workspaceId, repo.fullName).catch(e => {
-                console.warn('Failed to persist active repo:', e);
-            });
+            githubService.setActiveRepo(workspaceId, repo.fullName).catch(() => {});
         }
 
         try {
             const commits = await githubService.getCommits(repo.fullName.split('/')[0], repo.name);
             setGhCommits(commits);
-        } catch (e) {
-            console.error('Failed to fetch commits:', e);
+        } catch {
+            // Commits fetch failed silently
         } finally {
             setGhLoading(false);
         }
@@ -536,8 +533,7 @@ export default function Joe() {
                     setAgentSelected(targetSessionId);
                     await loadAllSessions();
                 }
-            } catch (e) {
-                console.error('Failed to create session on the fly', e);
+            } catch {
                 return;
             }
         }
@@ -571,8 +567,7 @@ export default function Joe() {
             } else {
                 await SocketService.sendMessage(targetSessionId, messageText);
             }
-        } catch (e) {
-            console.error('Failed to send message:', e);
+        } catch {
             setInputValue(messageText);
         } finally {
             setIsLoading(false);

--- a/web/src/services/socket.ts
+++ b/web/src/services/socket.ts
@@ -1,6 +1,8 @@
 import { API_URL, WS_URL } from '../config';
 import { AutoOpenManager } from './AutoOpenManager';
 
+const __DEV__ = import.meta.env.DEV;
+
 let socket: WebSocket | null = null;
 const listeners: Set<(data: any) => void> = new Set();
 const statusListeners: Set<(status: { state: string; detail?: string }) => void> = new Set();
@@ -110,20 +112,17 @@ async function probeAuth(token: string): Promise<'ok' | 'unauthorized' | 'error'
 }
 
 async function connect() {
-  console.log('[Socket Debug] connect() called');
   if (!WS_URL) {
-    console.error('[Socket Debug] WS_URL is missing or empty');
+    if (__DEV__) console.warn('[Socket] WS_URL is missing or empty');
     return;
   }
 
   // [Wakil 4.7] Strict Singleton Guard
   if (isConnecting) {
-    console.log('[Socket Debug] Already connecting... skipping.');
     return;
   }
 
   if (socket && socket.readyState === WebSocket.OPEN) {
-    console.log('[Socket Debug] Socket already open');
     return;
   }
 
@@ -131,14 +130,13 @@ async function connect() {
   if (connectingTimeoutTimer) clearTimeout(connectingTimeoutTimer);
   connectingTimeoutTimer = setTimeout(() => {
     if (isConnecting) {
-      console.warn('[Socket Debug] Connection attempt timed out, resetting isConnecting');
+      if (__DEV__) console.warn('[Socket] Connection attempt timed out, resetting');
       isConnecting = false;
       connect();
     }
   }, CONNECTING_TIMEOUT);
 
   const token = localStorage.getItem('token');
-  console.log('[Socket Debug] Token found:', token ? token.slice(0, 10) + '...' : 'null');
 
   if (connectTimer != null) {
     window.clearTimeout(connectTimer);
@@ -146,7 +144,6 @@ async function connect() {
   }
 
   if (await isApiShimActive()) {
-    console.log('[Socket Debug] API Shim Active, backing off');
     setStatus('error', 'api_shim');
     isConnecting = false; // UNLOCK on bail
     connectTimer = window.setTimeout(() => void connect(), 15000);
@@ -156,11 +153,10 @@ async function connect() {
   const primaryUrl = WS_URL;
   const fallbackUrl = computeFallbackWsUrl(primaryUrl);
   let urlToUse = (triedFallback || !fallbackUrl) ? primaryUrl : (connectAttempts > 0 ? fallbackUrl : primaryUrl);
-  console.log('[Socket Debug] Initial URL:', urlToUse);
 
   // Check max reconnection attempts
   if (connectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-    console.error(`[Socket] Max reconnection attempts (${MAX_RECONNECT_ATTEMPTS}) reached. Giving up.`);
+    if (__DEV__) console.warn(`[Socket] Max reconnection attempts (${MAX_RECONNECT_ATTEMPTS}) reached.`);
     setStatus('error', 'max_reconnect_attempts_exceeded');
     isConnecting = false;
     return;
@@ -172,7 +168,6 @@ async function connect() {
     u.searchParams.set('token', token);
   }
   urlToUse = u.toString();
-  console.log('[Socket Debug] Connecting to:', urlToUse);
 
   lastUrl = urlToUse;
 
@@ -187,13 +182,12 @@ async function connect() {
     }
     socket = new WebSocket(urlToUse);
   } catch (err) {
-    console.error('[Socket Debug] new WebSocket() threw:', err);
+    if (__DEV__) console.warn('[Socket] new WebSocket() threw:', err);
     isConnecting = false; // UNLOCK
     return;
   }
 
   socket.onopen = (event) => {
-    console.log('[Socket Debug] onopen fired');
     const ws = event.target as WebSocket;
     opened = true;
     isConnecting = false;
@@ -206,8 +200,6 @@ async function connect() {
     SocketService.send({ type: 'heartbeat', ts: Date.now() });
 
     // Flush pending safely using the socket instance that just opened
-    // Flush pending safely using the socket instance that just opened
-    console.log(`[Socket Debug] Flushing ${pendingQueue.length} items from queue.`);
     const toFlush = [...pendingQueue];
     pendingQueue = [];
 
@@ -216,7 +208,7 @@ async function connect() {
       try {
         ws.send(payload);
       } catch (err) {
-        console.error('[Socket Debug] Flush error:', err);
+        if (__DEV__) console.warn('[Socket] Flush error:', err);
       }
     }
   };
@@ -272,7 +264,6 @@ async function connect() {
       // Auto phase management based on events
       if (msgType === 'step_started') {
         if (!quietMode) {
-          console.log('[Socket] Auto-activating Quiet Mode (step_started)');
           quietMode = true;
           thinkingPhase = 'analyzing';
           thinkingPhaseListeners.forEach(cb => { try { cb('analyzing'); } catch { } });
@@ -289,7 +280,6 @@ async function connect() {
         }
       } else if (msgType === 'run_finished' || msgType === 'text') {
         if (quietMode) {
-          console.log('[Socket] Auto-deactivating Quiet Mode (run_finished/text)');
           quietMode = false;
           thinkingPhase = 'idle';
           thinkingStatus = '';
@@ -331,25 +321,21 @@ async function connect() {
       } else if (msgType === 'workspace_updated') {
         // [Pipeline Fix] When a new project is built, refresh File Explorer
         const wsData = data?.data || {};
-        console.log(`[Socket] Workspace updated to: ${wsData.path || wsData.name}`);
         window.dispatchEvent(new CustomEvent('workspace:updated', { detail: wsData }));
       } else if (msgType === 'build_progress') {
         // [Flow Agent] Live build progress events for PreviewPanel overlay
         const progressData = data?.data || {};
-        console.log(`[Socket] Build progress: ${progressData.phase} (${progressData.progress}%)`);
         window.dispatchEvent(new CustomEvent('preview:build_progress', { detail: progressData }));
       } else if (msgType === 'preview_ready' || msgType === 'preview_url') {
         // [Preview Pipeline] When the API sends a preview URL, dispatch it to PreviewPanel
         const url = data?.data?.url || data?.url;
         if (url) {
-          console.log(`[Socket] Preview URL received (${msgType}):`, url);
           _lastPreviewUrl = url;
           window.dispatchEvent(new CustomEvent('preview:ready', { detail: { url } }));
         } else if (msgType === 'preview_url' && data?.data?.type === 'refresh') {
           // If a refresh is requested but no new URL is provided, simply re-dispatch the last known URL
           // so the Preview Panel triggers an auto-switch at the end of long builds
           if (_lastPreviewUrl) {
-            console.log(`[Socket] Preview refresh requested, re-triggering auto-switch`);
             window.dispatchEvent(new CustomEvent('preview:ready', { detail: { url: _lastPreviewUrl } }));
           }
         }
@@ -358,7 +344,6 @@ async function connect() {
         const path = data?.data?.path;
         const content = data?.data?.content;
         if (path && content !== undefined) {
-          console.log(`[Socket] Code diff received for: ${path}`);
           window.dispatchEvent(new CustomEvent('preview:code_diff', { detail: { path, content } }));
         }
       }
@@ -373,7 +358,6 @@ async function connect() {
   };
 
   socket.onclose = (ev) => {
-    console.log('[Socket Debug] onclose:', ev.code, ev.reason);
     if (socket === ev.target) {
       socket = null;
     }
@@ -445,7 +429,6 @@ async function connect() {
   };
 
   socket.onerror = (e) => {
-    console.error('[Socket Debug] onerror:', e);
     isConnecting = false; // UNLOCK
     setStatus('error', lastUrl);
   };
@@ -470,7 +453,6 @@ export const SocketService = {
   },
   // [Wakil 5.1] Quiet Mode controls
   setQuietMode(enabled: boolean) {
-    console.log('[Socket] Quiet Mode:', enabled ? 'ON' : 'OFF');
     quietMode = enabled;
   },
   isQuietMode() {
@@ -482,7 +464,6 @@ export const SocketService = {
     const isCritical = data && criticalSignals.includes(data.type);
 
     if (quietMode && !isCritical) {
-      console.log('[Socket] HARD Quiet Mode: Blocked non-critical traffic:', data.type);
       return; // NO SEND. NO QUEUE. ZERO TRAFFIC.
     }
 
@@ -490,26 +471,22 @@ export const SocketService = {
 
     // [Wakil 5.1] Source-level deduplication
     if (msg === lastSentPayload) {
-      console.log('[Socket] Blocked duplicate payload');
       return;
     }
     lastSentPayload = msg;
 
     if (socket && socket.readyState === WebSocket.OPEN) {
-      console.log('[Socket] Sending:', msg);
       socket.send(msg);
     } else {
       // SMART QUEUEING & DEDUPLICATION
       if (data && data.type === 'terminal_resize') {
         const existingIdx = pendingQueue.findIndex(q => q && typeof q !== 'string' && q.type === 'terminal_resize' && q.id === data.id);
         if (existingIdx !== -1) {
-          console.log('[Socket] Internal Queue: Updating existing terminal_resize for', data.id);
-          pendingQueue[existingIdx] = data;
+            pendingQueue[existingIdx] = data;
           return;
         }
       }
 
-      console.warn('[Socket] Not connected. Queuing message type:', data.type);
       pendingQueue.push(data); // Store as object for better deduplication in future if needed
       if (!socket && !isConnecting) connect();
       else if (socket && socket.readyState === WebSocket.CLOSED && !isConnecting) connect();
@@ -535,7 +512,6 @@ export const SocketService = {
   },
   // [Wakil 5.3] Thinking Phase State
   setThinkingPhase(phase: 'analyzing' | 'synthesizing' | 'executing' | 'idle') {
-    console.log('[Socket] Thinking Phase:', phase);
     thinkingPhase = phase;
     thinkingPhaseListeners.forEach(cb => {
       try { cb(phase); } catch { }

--- a/web/src/store/sessionStore.ts
+++ b/web/src/store/sessionStore.ts
@@ -96,7 +96,7 @@ export const useSessionStore = create<SessionState>((set) => ({
       }));
     } catch (e: any) {
       if (e.message === 'Unauthorized' || e.message?.includes('Invalid token')) return;
-      console.error('Failed to load sessions', e);
+      // Session load failed silently
     }
   },
 
@@ -106,7 +106,7 @@ export const useSessionStore = create<SessionState>((set) => ({
       set({ folders });
     } catch (e: any) {
       if (e.message === 'Unauthorized' || e.message?.includes('Invalid token')) return;
-      console.error('Failed to load folders', e);
+      // Folder load failed silently
       set({ folders: [] });
     }
   },
@@ -116,8 +116,8 @@ export const useSessionStore = create<SessionState>((set) => ({
     try {
       await api.post('/folders', { name });
       await useSessionStore.getState().loadFolders();
-    } catch (e) {
-      console.error(e);
+    } catch {
+      // Folder creation failed silently
     } finally {
       set(state => ({ loadingStates: { ...state.loadingStates, creatingFolder: false } }));
     }
@@ -129,8 +129,8 @@ export const useSessionStore = create<SessionState>((set) => ({
       await api.delete(`/folders/${id}`);
       await useSessionStore.getState().loadFolders();
       await useSessionStore.getState().loadAllSessions();
-    } catch (e) {
-      console.error(e);
+    } catch {
+      // Folder deletion failed silently
     } finally {
       set(state => ({ loadingStates: { ...state.loadingStates, [`deleting-folder-${id}`]: false } }));
     }
@@ -141,8 +141,8 @@ export const useSessionStore = create<SessionState>((set) => ({
     try {
       await api.delete(`/sessions/${id}`);
       await useSessionStore.getState().loadAllSessions();
-    } catch (e) {
-      console.error(e);
+    } catch {
+      // Session deletion failed silently
     } finally {
       set(state => ({ loadingStates: { ...state.loadingStates, [`deleting-session-${id}`]: false } }));
     }
@@ -153,8 +153,8 @@ export const useSessionStore = create<SessionState>((set) => ({
     try {
       await api.delete('/sessions');
       set({ sessions: [], agentSessions: [], selected: null, agentSelected: null });
-    } catch (e) {
-      console.error(e);
+    } catch {
+      // Session deletion failed silently
     } finally {
       set(state => ({ loadingStates: { ...state.loadingStates, deletingAll: false } }));
     }


### PR DESCRIPTION
# fix: Clean up all console noise in Joe interface

## Summary
Removes ~40+ debug `console.log`, `console.error`, `console.warn`, and `console.debug` calls across the Joe frontend to produce a clean browser console. Changes span 7 files:

- **`socket.ts`**: Removed all `[Socket Debug]` and `[Socket]` log statements. A few critical failure paths (missing WS_URL, max reconnect, WebSocket constructor throw, flush error, connection timeout) retain logging behind an `if (__DEV__)` guard using `import.meta.env.DEV`.
- **`main.tsx`**: Extended the global noise filter to suppress `[Socket Debug]` prefixed messages, React Router Future Flag warnings, and React DevTools prompts. Added `future` flags to `<BrowserRouter>` to address React Router v7 deprecation warnings.
- **`Joe.tsx`**: Silenced all `console.error`/`console.log` in catch blocks (message load, workspace, GitHub, session creation, send).
- **`EmbeddedTerminal.tsx`**: Removed 3 debug `console.log` calls and 3 `console.debug` calls (input blocked, resize blocked, resize dimensions, fit error, resize error, dispose error).
- **`EmbeddedBrowser.tsx`**: Silenced navigation/action error logging.
- **`ChatPanel.tsx`**: Replaced debug `console.log` in code citation click handler with `void 0`.
- **`sessionStore.ts`**: Silenced all `console.error` calls in CRUD operations for sessions/folders.

## Updates since initial revision
- **Narrowed noise filter**: `main.tsx` now only filters `[Socket Debug]` (not all `[Socket]` messages), so the `__DEV__` warnings in `socket.ts` using `[Socket]` prefix will correctly appear in dev mode.
- **Fixed indentation**: Corrected indentation regressions in `EmbeddedTerminal.tsx` for the quiet-mode return and resize send.
- **Removed `console.debug` calls**: Cleaned up 3 additional `console.debug` calls in `EmbeddedTerminal.tsx` (fit error, resize error, dispose error).

## Review & Testing Checklist for Human
- [ ] **Silent error swallowing**: All `catch` blocks now drop errors silently. If workspace creation, GitHub init, message sending, or session creation fails, there is zero console output and no user-facing notification. Verify this is acceptable or consider adding toast/notification for user-facing failures (especially `handleSend` in Joe.tsx).
- [ ] **BrowserRouter future flags**: Test that `future={{ v7_startTransition: true, v7_relativeSplatPath: true }}` does not change any routing behavior (navigation, redirects, splat routes).
- [ ] **Minor indentation**: In `socket.ts`, the line `pendingQueue[existingIdx] = data;` (in the `send` method's terminal_resize dedup block) picked up extra leading spaces. Cosmetic only but worth a glance.
- [ ] **Test plan**: Open the Joe interface with Chrome DevTools console open. Navigate around, trigger chat messages, switch workspace tabs, connect/disconnect terminal, and verify the console is clean. Also deliberately cause a failure (e.g., disconnect network) and confirm the app still behaves gracefully.

### Notes
- Requested by @yasoo2
- [Link to Devin session](https://app.devin.ai/sessions/dcd97469e24f4087a1499910adcef60b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yasoo2/xelitesolutions/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
