### PR TITLE
feat: upgrade Joe to advanced engineering agent (Devin-style)

### DIFF
--- a/api/src/llm.ts
+++ b/api/src/llm.ts
@@ -307,15 +307,13 @@ export function selectToolDefsForProvider(
     /\b(image|png|jpg|jpeg|generate image)\b/i.test(routingTextRaw) ||
     /صورة|صور/i.test(routingTextRaw);
 
-  let computedLimit = 72;
-  if (routingTextRaw.length < 140) computedLimit = 56;
-  if (routingTextRaw.length > 700) computedLimit = 96;
-  if (wantsBrowser) computedLimit = Math.max(computedLimit, 88);
-  if (wantsSearch) computedLimit = Math.max(computedLimit, 80);
-  if (wantsFs) computedLimit = Math.max(computedLimit, 80);
-  if (wantsQuality) computedLimit = Math.max(computedLimit, 80);
-  if (wantsGit) computedLimit = Math.max(computedLimit, 72);
-  if (wantsImage) computedLimit = Math.max(computedLimit, 72);
+  // Upgraded: Always provide a generous tool limit so the LLM has more choices
+  // The LLM is better at selecting the right tool when it can see more options
+  let computedLimit = 96; // Base: generous default
+  if (routingTextRaw.length > 500) computedLimit = 128; // Complex tasks get more tools
+  if (wantsBrowser || wantsFs || wantsShell || wantsQuality || wantsGit) {
+    computedLimit = Math.max(computedLimit, 112); // Multi-domain tasks get maximum visibility
+  }
   const effectiveLimit = Math.max(
     PRIORITY_TOOL_NAMES.length,
     Math.min(limit, computedLimit),
@@ -703,18 +701,59 @@ After building ANY project or making ANY code changes, you MUST verify before re
 5. **Final Report**: In your \`echo\`, list: (a) what was built, (b) what was tested, (c) result (pass/fail).
 CRITICAL: NEVER use \`echo\` to report success if you haven't verified the build passes.
 
-### 🔧 ERROR RECOVERY STRATEGY:
-When a tool fails or code has errors, DO NOT give up:
-1. **Read the Error**: Parse the full error message — identify the file, line number, and error type.
-2. **Diagnose**: Common errors and fixes:
-   - "Module not found" → Run \`npm install <package>\`
-   - "Type error" → Check TypeScript types, add missing imports
-   - "Syntax error" → Read the problematic file and fix the syntax
-   - "Port in use" → Use \`shell_execute\` to find and kill the process
-   - "Permission denied" → Try with different path or check file permissions
-3. **Fix and Retry**: Make the fix, then re-run the failing command.
-4. **Pivot if Stuck**: If the same approach fails 3 times, try a fundamentally different strategy.
-5. **NEVER report an error to the user without attempting at least 2 fixes first.**
+### 🔧 ADVANCED ERROR RECOVERY & SELF-HEALING:
+When a tool fails or code has errors, you MUST self-heal like an advanced engineering agent:
+
+**Step 1 — Diagnose Automatically:**
+- Parse the full error message — identify file, line number, error type.
+- Use \`read_file\` to inspect the failing file around the error line.
+- Use \`shell_execute\` with \`grep\` or \`find\` to locate related files.
+
+**Step 2 — Auto-Fix Common Errors:**
+| Error Pattern | Auto-Fix Action |
+|---|---|
+| "Module not found" / "Cannot find module" | Run \`npm install <package>\` or check import paths |
+| "Type error" / "Property does not exist" | Read the type definition, add correct types/imports |
+| "Syntax error" | Read the file, identify the syntax issue, use \`file_edit\` to fix |
+| "Port in use" / "EADDRINUSE" | Run \`lsof -i :<port>\` then \`kill <pid>\` |
+| "Permission denied" | Check path exists, try alternative path |
+| "ENOENT" / "No such file" | Use \`ls\` to check path, create missing directories with \`mkdir -p\` |
+| "Build failed" | Read build output, fix errors in order (first error first) |
+| "Test failed" | Read test output, fix the failing assertion or the code it tests |
+| "Git conflict" | Read the conflicting file, resolve manually with \`file_edit\` |
+
+**Step 3 — Apply Fix and Verify:**
+- Make the fix using \`file_edit\` or \`shell_execute\`.
+- Re-run the original failing command to verify the fix works.
+- If the fix creates new errors, fix those too (chain fixes).
+
+**Step 4 — Escalation Strategy:**
+- If the same approach fails 3 times → pivot to a fundamentally different strategy.
+- If 5 different approaches all fail → use \`notify_user\` to explain what you tried and ask for guidance.
+- **NEVER report an error to the user without attempting at least 3 fixes first.**
+
+### 🏗️ ADVANCED ENGINEERING PATTERNS (Devin-Style):
+When working on complex software engineering tasks:
+
+**Code Understanding:**
+- Before modifying code, ALWAYS read the surrounding context (at least 50 lines around the target).
+- Check imports, type definitions, and related files before making changes.
+- Use \`grep_search\` to find all references to a function/variable before renaming or modifying it.
+
+**Incremental Development:**
+- Make small, focused changes. Verify each change before moving to the next.
+- After every code change, run the relevant build/lint/test command.
+- Commit working changes frequently with descriptive messages.
+
+**Debugging Methodology:**
+- Start with the error message, then trace backwards through the call stack.
+- Add temporary \`console.log\` statements if needed, then remove them after debugging.
+- Check recent git history to see what changed if something suddenly breaks.
+
+**Project Navigation:**
+- Use \`project_detect\` once at the start to understand the tech stack.
+- Use \`ls\` and \`read_file\` on package.json, tsconfig.json, etc. to understand the build system.
+- Map out the directory structure before diving into specific files.
 
 ### 📐 CODE QUALITY STANDARDS:
 When writing code, follow these standards:
@@ -1424,296 +1463,49 @@ export async function planNextStep(
       }
     }
 
-    // Unified context injection point
+    // === LLM-First Tool Selection (Advanced Engineering Mode) ===
+    // Instead of regex pattern matching, we now prioritize sending tools to the LLM
+    // for native function calling. This is how Devin AI and other advanced agents work.
+    // Regex patterns are kept only as a fast-path fallback for obvious cases.
 
-    // === Pattern Detection ===
-
-    // Browser patterns
-    const browserPatterns = {
-      open: /(open|افتح|ادخل|زور|اذهب|visit|go to|browse|شوف|طالع|ودني|وديني|خلني|بدي|ابغى|عايز)\s+(https?:\/\/|www\.|google|youtube|github|facebook|twitter|x\.com|instagram|tiktok|linkedin)/i,
-      hasUrl: /https?:\/\/[^\s]+/i,
-      multiStep:
-        /(then|ثم|بعد|بعدها|وبعدين|click|انقر|اضغط|دوس|type|اكتب|املأ|extract|استخرج|لخص|انسخ)/i,
-      analyze: /(analyze|تحليل|فحص|دراسة)\s+(https?:\/\/|www\.)/i,
-    };
-
-    // Search patterns (expanded for weather, news, current events, and people in power)
-    const searchPatterns =
-      /(ابحث|بحث|search|find|lookup|دور|فتش|شوف|طالع|لاقي|اطلع|ابغى|عايز|بدي|ماهي|ما\s*هي|ما\s*هو|من\s*هو|من\s*هي|رئيس|حاكم|ملك|وزير|من\s*هو\s*رئيس|الحالي|كيف\s*هو|كيف\s*احوال|احوال|درجة\s*حرارة|سعر|now|current|weather|طقس|جو|اخبار|news|price|stock|who\s*is|president|ruler|king|minister|latest|capital\s*of)\s+(عن|على|for|about|في|بـ|هو|هي)?/i;
-
-    // File patterns (expanded)
-    const filePatterns = {
-      read: /(read|اقرأ|قراءة|شوف|طالع|اعرض|افتح)\s+(file|ملف|الملف)/i,
-      write: /(write|اكتب|create|انشئ|سوي|اعمل|كون)\s+(file|ملف)/i,
-      list: /(list|show|عرض|اعرض|شوف|طالع|ls)\s+(files|الملفات|ملفات)/i,
-    };
-
-    // Code generation patterns (expanded)
-    const codePatterns =
-      /(اكتب|كود|code|function|دالة|class|كلاس|component|كومبوننت|api|endpoint|script|سكريبت|program|برنامج|تطبيق|application|app|نظام|system|sوي|اعمل|ابني|انشئ|طور|build|create|develop|implement|نفذ)/i;
+    // Quick URL extraction for browser shortcuts only
+    const hasExplicitUrl = /https?:\/\/[^\s]+/i.test(userText);
+    const isExplicitBrowserOpen = /(open|افتح|visit|زور|اذهب|go to)\s+(https?:\/\/)/i.test(userText);
 
     try {
-      // 1. Browser requests
-      if (
-        browserPatterns.open.test(userText) ||
-        browserPatterns.hasUrl.test(userText)
-      ) {
+      // FAST PATH: Only handle the most obvious browser URL opens via regex
+      // Everything else goes through LLM with tool definitions
+      if (isExplicitBrowserOpen && hasExplicitUrl) {
         const urlMatch = userText.match(/https?:\/\/[^\s]+/);
-        const url = urlMatch
-          ? urlMatch[0]
-          : userText.match(/google/i)
-            ? "https://www.google.com"
-            : userText.match(/youtube/i)
-              ? "https://www.youtube.com"
-              : userText.match(/github/i)
-                ? "https://github.com"
-                : userText.match(/facebook/i)
-                  ? "https://www.facebook.com"
-                  : userText.match(/instagram/i)
-                    ? "https://www.instagram.com"
-                    : userText.match(/twitter|x\.com/i)
-                      ? "https://x.com"
-                      : "";
-
-        if (url) {
-          if (browserPatterns.analyze.test(userText)) {
-            console.info("[Auto Enterprise] → Browser Analysis Task");
-            return {
-              name: "browser_run",
-              input: {
-                sessionId: `browser_${Date.now()}`,
-                instructionText: `Visit this repository and perform a deep architectural analysis: ${url}`,
-              },
-            };
-          }
-          if (browserPatterns.multiStep.test(userText)) {
-            console.info("[Auto Enterprise] → Browser Multi-Step Task");
-            return {
-              name: "browser_run",
-              input: {
-                sessionId: `browser_${Date.now()}`,
-                instructionText: userText,
-              },
-            };
-          } else {
-            console.info("[Auto Enterprise] → Browser Open");
-            return {
-              name: "browser_open",
-              input: {
-                url,
-                sessionId: `browser_${Date.now()}`,
-              },
-            };
-          }
-        }
-      }
-
-      // 2. Web search requests
-      if (searchPatterns.test(userText)) {
-        console.info("[Auto Enterprise] → Web Search");
-        return {
-          name: "web_search",
-          input: { query: userText },
-        };
-      }
-
-      // 3. File operations
-      if (filePatterns.read.test(userText)) {
-        const fileMatch = userText.match(
-          /(read|اقرأ|قراءة|شوف|طالع|اعرض|افتح)\s+(file|ملف|الملف)\s+(.+)/i,
-        );
-        const filePath = fileMatch?.[3]?.trim() || ".";
-        console.info("[Auto Enterprise] → Read File");
-        return {
-          name: "file_read",
-          input: { filePath },
-        };
-      }
-
-      if (filePatterns.list.test(userText) || /^ls$/i.test(userText.trim())) {
-        console.info("[Auto Enterprise] → List Files");
-        return {
-          name: "ls",
-          input: { path: "." },
-        };
-      }
-
-      // Simple build requests (any app/calculator/game/tool request)
-      const simpleBuildPatterns =
-        /(build|create|make|ابني|انشئ|أنشئ|سوي|اعمل)\s+(.{0,20})?(calculator|game|todo|app|tool|store|shop|حاسبة|لعبة|مهام|تطبيق|أداة|متجر|دكان)/i;
-
-      // Large-scale build patterns (enterprise systems)
-      const largeBuildPatterns =
-        /(build|create|develop|implement|ship|launch|ابني|انشئ|أنشئ|طور|نفذ|ابغى|عايز|بدي)\s+(.{0,40})?(system|platform|application|backend|api|service|microservice|dashboard|portal|saas|نظام|منصة|خدمة|ميكروسيرفس)/i;
-      const explicitLargeScale =
-        /(enterprise|large[\s-]?scale|microservices|multi[\s-]?tenant|kubernetes|docker|terraform|ci\/cd|scalable|ضخم|ضخمة|واسع|واسعة|مؤسسي)/i;
-
-      const isBuildingWebsite =
-        /(صفحة|موقع|هبوط|landing|page|website|builder|متجر|دكان|store|shop)/i.test(userText);
-
-      const wordCountInLlm = (userText || "").trim().split(/\s+/).length;
-      const isInstructional =
-        /^\d+[\.\)]|[\*•-]\s/m.test(userText) || // Numbering or bullets
-        /(step|rule|instruction|قواعد|خطوات|اولا|ثانيا|أولا|ثانياً)/i.test(userText) ||
-        wordCountInLlm > 20;
-
-
-      const parseWebsitePipelineInput = () => {
-        const text = String(userText || "");
-        const lower = text.toLowerCase();
-        const nameMatch =
-          text.match(/(?:named|called)\s+([a-z0-9_-]{2,})/i) ||
-          text.match(/(?:اسم|اسمه|سميه|سَمِّه|سمه)\s+([a-z0-9_-]{2,})/i);
-        const name = String(nameMatch?.[1] || "").trim() || "mega-web";
-
-        const isEcom =
-          /(ecommerce|e-commerce|shop|store|checkout|cart|stripe|paypal|payments?|سلة|دفع|متجر|تجارة\s*الكترونية)/i.test(
-            text,
-          );
-        const isBlog = /(blog|مدونة|مقال|مقالات|اخبار|أخبار)/i.test(text);
-        const type = isEcom ? "ecommerce" : isBlog ? "blog" : "saas";
-
-        const features = Array.from(
-          new Set(
-            [
-              /(auth|login|signup|oauth|jwt|مصادقة|تسجيل\s*الدخول|حسابات)/i.test(
-                text,
-              )
-                ? "auth"
-                : null,
-              /(admin|dashboard|cms|لوحة|لوحه|تحكم|ادارة|إدارة)/i.test(text)
-                ? "admin"
-                : null,
-              /(payment|checkout|stripe|paypal|دفع|بوابة\s*دفع)/i.test(text)
-                ? "payments"
-                : null,
-              /(search|filter|فلاتر|بحث)/i.test(text) ? "search" : null,
-              /(seo|سيو|meta|structured\s*data)/i.test(text) ? "seo" : null,
-              /(i18n|multilingual|arabic|english|عربي|انجليزي|ثنائي)/i.test(
-                text,
-              )
-                ? "i18n"
-                : null,
-            ].filter(Boolean) as string[],
-          ),
-        );
-
-        const aestheticMode = /(glass|زجاج)/i.test(text)
-          ? "glass"
-          : /(neon|نيون)/i.test(text)
-            ? "neon"
-            : /(minimal|مينيمال|بسيط)/i.test(text)
-              ? "minimal"
-              : /(corporate|رسمي|شركات)/i.test(text)
-                ? "corporate"
-                : undefined;
-
-        const language =
-          analysis?.language === "ar"
-            ? "ar"
-            : analysis?.language === "mixed"
-              ? "dual"
-              : "en";
-
-        const qualityTasks = ["lint", "typecheck", "test", "build"];
-        return {
-          name,
-          type,
-          features,
-          qualityTasks,
-          securityChecks: true,
-          autoFix: true,
-          aestheticMode,
-          language,
-        };
-      };
-
-      // [STUPID JOE FIX] Simple build requests → Use standard Orchestrator
-      if (!isInstructional && !isBuildingWebsite && simpleBuildPatterns.test(userText)) {
-        console.info(
-          "[Auto Enterprise] → Simple Build Detected: Routing to Agent Orchestrator",
-        );
-        return {
-          name: "website_full_pipeline",
-          input: { name: "mega-web", type: "saas", features: [], qualityTasks: ["lint", "typecheck", "test", "build"], securityChecks: true, autoFix: true, language: analysis?.language === "ar" ? "ar" : "en" },
-        };
-      }
-
-      // Large-scale builds → Agent Orchestrator
-      if (
-        !isInstructional &&
-        !isBuildingWebsite &&
-        (analysis.type === "code_generation" || codePatterns.test(userText)) &&
-        (analysis.complexity === "extreme" ||
-          explicitLargeScale.test(userText) ||
-          largeBuildPatterns.test(userText))
-      ) {
-        console.info("[Auto Enterprise] → Large Build Detected: Routing to Agent Orchestrator");
-        return {
-          name: "website_full_pipeline",
-          input: { name: "mega-web", type: "saas", features: ["auth", "admin", "payments"], qualityTasks: ["lint", "typecheck", "test", "build"], securityChecks: true, autoFix: true, language: analysis?.language === "ar" ? "ar" : "en" },
-        };
-      }
-
-      // 4. Code generation (let the intelligent model handle it via echo)
-      if (codePatterns.test(userText) && analysis.type === "code_generation") {
-        if (isBuildingWebsite && !isInstructional) {
-          if (
-            analysis.complexity === "extreme" ||
-            explicitLargeScale.test(userText) ||
-            largeBuildPatterns.test(userText)
-          ) {
-            console.info(
-              "[Auto Enterprise] → Large Website Build Detected: Routing to Agent Orchestrator",
-            );
-            return {
-              name: "website_full_pipeline",
-              input: parseWebsitePipelineInput(),
-            };
-          }
-          console.info(
-            "[Auto Enterprise] → Detected Website Build Request - using Pipeline",
-          );
+        if (urlMatch) {
+          console.info("[Auto Enterprise] → Fast Path: Explicit URL Open");
           return {
-            name: "website_full_pipeline",
-            input: parseWebsitePipelineInput(),
+            name: "browser_open",
+            input: {
+              url: urlMatch[0],
+              sessionId: `browser_${Date.now()}`,
+            },
           };
         }
-
-        console.info(
-          "[Auto Enterprise] → Code Generation via Intelligent Model",
-        );
-        const msgs = [
-          {
-            role: "system",
-            content:
-              "You are an expert software engineer. Generate clean, production-ready code with best practices.",
-          },
-          ...messages,
-        ];
-        const codeResponse = await routeToModel(
-          msgs,
-          analysis,
-          undefined,
-          undefined,
-          options?.onProgress,
-          options?.onThought,
-          tools
-        );
-        return {
-          name: "echo",
-          input: { text: codeResponse },
-        };
       }
 
-      // 5. General chat/questions - Use intelligent router with full persona
+
+      // === LLM-DRIVEN TOOL SELECTION (Advanced Engineering Mode) ===
+      // All task types (code gen, file ops, search, etc.) now go through the LLM
+      // with full tool definitions. The LLM decides which tool to use.
       console.info(
-        `[Auto Enterprise] → Intelligent Chat via ${selectedModel.name}`,
+        `[Auto Enterprise] → LLM-First Tool Selection via ${selectedModel.name}`,
       );
 
-      // [TOOL AWARENESS] Build condensed tool catalog for LLM visibility
-      const toolCatalog = tools.map(t => `- **${t.name}**: ${t.description}`).join('\n');
-      const toolAwarenessBlock = `\n\n## Available Tools (${tools.length}+)\nIf the user's request requires executing a tool, respond ONLY with JSON: {"name":"<tool_name>","input":{<params>}}\n\n### Strategic Guidance for Agents:\n1. **Discovery Turn**: If you don't know the project structure, start with \`project_detect\`. \n2. **Analysis Turn**: If you already see the structure in history, DO NOT repeat \`project_detect\`. Instead, use \`analyze_codebase\` or \`file_read\` on key files (e.g., package.json, src/index.ts) to understand logic.\n3. **Avoid Loops**: Do not call the same tool with the same inputs multiple times without a clearly different purpose.\n\n${toolCatalog}`;
+      // Build strategic tool catalog with parameter hints for LLM
+      const toolCatalog = tools.map(t => {
+        const params = t.inputSchema?.properties
+          ? Object.keys(t.inputSchema.properties).join(', ')
+          : '';
+        return `- **${t.name}**${params ? ` (${params})` : ''}: ${t.description}`;
+      }).join('\n');
+
+      const toolAwarenessBlock = `\n\n## YOUR TOOLS (${tools.length}+)\nYou MUST use tools to accomplish tasks. To call a tool, respond ONLY with a JSON block:\n{"name":"<tool_name>","input":{<params>},"reasoning":"why this tool"}\n\n### ENGINEERING STRATEGY:\n1. **Explore First**: Use \`ls\`, \`project_detect\`, \`read_file\` to understand the project before making changes.\n2. **Plan Then Execute**: For complex tasks, use \`todo_write\` to create a plan, then execute step-by-step.\n3. **Verify After Changes**: After writing code, use \`shell_execute\` to build/test. Fix errors before reporting.\n4. **Use Git**: Commit and push changes with \`git_ops\`.\n5. **Never Guess**: If unsure about file structure, read it. If unsure about dependencies, check package.json.\n6. **Self-Heal**: If a command fails, read the error, diagnose it, and fix it automatically.\n7. **Anti-Loop**: Never call the same tool with the same params more than twice. Pivot strategy if stuck.\n\n### TOOL CATALOG:\n${toolCatalog}`;
 
       const msgs = [
         {

--- a/api/src/services/AgentLoopService.ts
+++ b/api/src/services/AgentLoopService.ts
@@ -171,13 +171,15 @@ export class AgentLoopService {
         let steps = 0;
         const runCfg = getSessionRunConfig(sessionId);
         const isPerpetual = runCfg?.kind === 'agent' || runCfg?.perpetual === true;
-        const MAX_STEPS = isPerpetual ? 50 : 10; // Reduced from 500 to prevent runaway loops
+        const MAX_STEPS = isPerpetual ? 200 : 50; // Upgraded: Allow more steps for complex engineering tasks
 
-        // Circuit Breaker State (Wakil 4.1)
+        // Circuit Breaker State (Wakil 4.1 - Enhanced)
         let lastErrorHash: string | null = null;
         let consecutiveFailures = 0;
         let lastToolSignature: string | null = null;
+        let consecutiveIdenticalTools = 0;
         const blacklist = new Set<string>(); // Wakil 4.4: Task-level blacklist
+        const toolHistory: Array<{ name: string; ok: boolean; timestamp: number }> = []; // Track tool execution history for smart recovery
 
         let currentRunId = initialRunId;
 
@@ -189,8 +191,32 @@ export class AgentLoopService {
                 messages = await Message.find({ sessionId }).sort({ createdAt: 1 }).lean();
             }
 
-            // 2. Plan Next Step (LLM)
-            const msgsForLLM = messages.map(m => ({ role: m.role || 'user', content: String(m.content || '') }));
+            // 2. Plan Next Step (LLM) — with Smart Context Summarization
+            let msgsForLLM = messages.map(m => ({ role: m.role || 'user', content: String(m.content || '') }));
+
+            // Smart Context Window: Summarize old messages to prevent context overflow
+            if (msgsForLLM.length > 30) {
+                const userGoal = msgsForLLM.find(m => m.role === 'user');
+                const recentMessages = msgsForLLM.slice(-20);
+                const olderMessages = msgsForLLM.slice(0, -20);
+
+                // Build a summary of older tool executions
+                const toolActions = olderMessages
+                    .filter(m => m.content.includes('execute:') || m.content.includes('Tool Call:') || m.content.includes('✅') || m.content.includes('❌'))
+                    .map(m => {
+                        const content = m.content.slice(0, 150);
+                        return content;
+                    });
+
+                const summaryText = `## Previous Actions Summary (${olderMessages.length} messages summarized):\n` +
+                    (toolActions.length > 0 ? toolActions.join('\n') : 'No significant tool actions in older messages.');
+
+                msgsForLLM = [
+                    ...(userGoal ? [userGoal] : []),
+                    { role: 'assistant' as const, content: summaryText },
+                    ...recentMessages
+                ];
+            }
 
             // Check run config
             const runCfg = getSessionRunConfig(sessionId);
@@ -253,16 +279,31 @@ export class AgentLoopService {
             const inputStr = JSON.stringify(plan.input || {});
             const currentSignature = `${plan.name}:${inputStr}`;
 
-            if (blacklist.has(currentSignature) || currentSignature === lastToolSignature) {
-                const abortMsg = blacklist.has(currentSignature)
-                    ? `⚠️ Blacklisted: Refusing to repeat previously forbidden/failed action \`${plan.name}\`.`
-                    : `⚠️ No State Change: Refusing to repeat \`${plan.name}\` with identical input.`;
-
+            if (blacklist.has(currentSignature)) {
+                const abortMsg = `⚠️ Blacklisted: Refusing to repeat previously forbidden/failed action \`${plan.name}\`. Pivoting strategy...`;
                 broadcast({ type: 'text', runId: currentRunId, data: abortMsg });
                 try {
                     if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: abortMsg, runId: currentRunId });
                 } catch { }
-                break;
+                // Don't break — let the LLM see the blacklist message and pivot to a different approach
+                continue;
+            }
+
+            // Track consecutive identical tool calls (allow 2 retries before flagging)
+            if (currentSignature === lastToolSignature) {
+                consecutiveIdenticalTools++;
+                if (consecutiveIdenticalTools >= 3) {
+                    const pivotMsg = `⚠️ Loop Detected: \`${plan.name}\` called 3 times with identical input. Forcing strategy pivot.`;
+                    broadcast({ type: 'text', runId: currentRunId, data: pivotMsg });
+                    try {
+                        if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: pivotMsg, runId: currentRunId });
+                    } catch { }
+                    blacklist.add(currentSignature);
+                    consecutiveIdenticalTools = 0;
+                    continue;
+                }
+            } else {
+                consecutiveIdenticalTools = 0;
             }
             lastToolSignature = currentSignature;
 
@@ -297,16 +338,17 @@ export class AgentLoopService {
                     lastErrorHash = errorHash;
                 }
 
-                if (consecutiveFailures >= (isPerpetual ? 5 : 3)) { // Allow 3 retries before tripping (was 1)
+                if (consecutiveFailures >= (isPerpetual ? 8 : 5)) { // Enhanced: Allow more retries for complex tasks
                     blacklist.add(currentSignature); // Wakil 4.4: Add failing signature to blacklist
                     console.error(`[AgentLoop] Blacklisted failing action: ${currentSignature}`);
                     console.error(`[AgentLoop] Circuit Breaker Tripped: Consecutive failure for ${plan.name}`);
-                    const abortMsg = `⚠️ Max retries exceeded for \`${plan.name}\`. Aborting to prevent infinite loop.`;
-                    broadcast({ type: 'text', runId: newRunId, data: abortMsg });
+                    const recoveryMsg = `⚠️ Tool \`${plan.name}\` failed ${consecutiveFailures} times. Blacklisting and attempting alternative approach...`;
+                    broadcast({ type: 'text', runId: newRunId, data: recoveryMsg });
                     try {
-                        if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: abortMsg, runId: newRunId });
+                        if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: recoveryMsg, runId: newRunId });
                     } catch { }
-                    break;
+                    // Don't break — let the LLM attempt recovery with the error context
+                    continue;
                 }
             } else {
                 lastErrorHash = null;
@@ -346,13 +388,23 @@ export class AgentLoopService {
             }
             try { if (!offlineMode) await Run.findByIdAndUpdate(newRunId, { $set: { status: result.ok ? 'done' : 'failed' } }); } catch { }
 
+            // Track tool execution for smart recovery
+            toolHistory.push({ name: plan.name, ok: result.ok ?? false, timestamp: Date.now() });
+
             // If tool failed, let the LLM see the error and attempt recovery
-            // DO NOT break immediately — the error is now in the message history
-            // The LLM will analyze it and decide whether to fix or abort
             if (!result.ok) {
-                console.log(`[AgentLoop] Tool '${plan.name}' failed. Letting LLM attempt self-recovery...`);
-                // Continue the loop — the next iteration will call planNextStep
-                // with the error in the conversation, allowing the LLM to diagnose and fix
+                const errorContext = typeof result.error === 'string' ? result.error : 'Unknown error';
+                console.log(`[AgentLoop] Tool '${plan.name}' failed: ${errorContext.slice(0, 200)}. Letting LLM attempt self-recovery...`);
+
+                // Inject recovery hint into the conversation
+                const recentFailures = toolHistory.filter(t => !t.ok && Date.now() - t.timestamp < 60000);
+                if (recentFailures.length >= 3) {
+                    const recoveryHint = `🔧 Recovery Hint: ${recentFailures.length} tools failed in the last minute. Consider: 1) Check if the file/path exists, 2) Try a different approach, 3) Read error output carefully, 4) Use \`ls\` or \`project_detect\` to understand the current state.`;
+                    broadcast({ type: 'text', runId: newRunId, data: recoveryHint });
+                    try {
+                        if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: recoveryHint, runId: newRunId });
+                    } catch { }
+                }
                 continue;
             }
 

--- a/api/src/services/AgentLoopService.ts
+++ b/api/src/services/AgentLoopService.ts
@@ -211,8 +211,10 @@ export class AgentLoopService {
                 const summaryText = `## Previous Actions Summary (${olderMessages.length} messages summarized):\n` +
                     (toolActions.length > 0 ? toolActions.join('\n') : 'No significant tool actions in older messages.');
 
+                // Only prepend userGoal if it's not already in recentMessages
+                const userGoalInRecent = userGoal && recentMessages.includes(userGoal);
                 msgsForLLM = [
-                    ...(userGoal ? [userGoal] : []),
+                    ...(userGoal && !userGoalInRecent ? [userGoal] : []),
                     { role: 'assistant' as const, content: summaryText },
                     ...recentMessages
                 ];

--- a/api/src/services/AgentLoopService.ts
+++ b/api/src/services/AgentLoopService.ts
@@ -285,7 +285,8 @@ export class AgentLoopService {
                 try {
                     if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: abortMsg, runId: currentRunId });
                 } catch { }
-                // Don't break — let the LLM see the blacklist message and pivot to a different approach
+                // Mark run as skipped to avoid orphaned 'running' records
+                try { if (!offlineMode) await Run.findByIdAndUpdate(newRunId, { $set: { status: 'skipped' } }); } catch { }
                 continue;
             }
 
@@ -300,6 +301,8 @@ export class AgentLoopService {
                     } catch { }
                     blacklist.add(currentSignature);
                     consecutiveIdenticalTools = 0;
+                    // Mark run as skipped to avoid orphaned 'running' records
+                    try { if (!offlineMode) await Run.findByIdAndUpdate(newRunId, { $set: { status: 'skipped' } }); } catch { }
                     continue;
                 }
             } else {
@@ -343,11 +346,24 @@ export class AgentLoopService {
                     console.error(`[AgentLoop] Blacklisted failing action: ${currentSignature}`);
                     console.error(`[AgentLoop] Circuit Breaker Tripped: Consecutive failure for ${plan.name}`);
                     const recoveryMsg = `⚠️ Tool \`${plan.name}\` failed ${consecutiveFailures} times. Blacklisting and attempting alternative approach...`;
+                    // Broadcast step_failed since step_started was already sent
+                    const eventResult = sanitizeToolResultForBroadcast(plan.name, result);
+                    broadcast({ type: 'step_failed', runId: newRunId, data: { name: `execute:${plan.name}`, result: eventResult } });
                     broadcast({ type: 'text', runId: newRunId, data: recoveryMsg });
                     try {
                         if (!offlineMode) await Message.create({ sessionId, role: 'assistant', content: recoveryMsg, runId: newRunId });
                     } catch { }
-                    // Don't break — let the LLM attempt recovery with the error context
+                    // Save ToolExecution record for audit trail
+                    try {
+                        if (!offlineMode) {
+                            await ToolExecution.create({
+                                runId: newRunId, sessionId, name: plan.name || 'unknown',
+                                input: persistedInput, output: result.output, ok: result.ok, logs: result.logs,
+                            });
+                        }
+                    } catch { }
+                    // Update Run status to avoid orphaned 'running' records
+                    try { if (!offlineMode) await Run.findByIdAndUpdate(newRunId, { $set: { status: 'failed' } }); } catch { }
                     continue;
                 }
             } else {

--- a/api/src/tools/definitions/SystemTools.ts
+++ b/api/src/tools/definitions/SystemTools.ts
@@ -101,7 +101,30 @@ function splitCommandLine(raw: string) {
 
 function isAllowedLocalCommand(command: string) {
     const c = String(command || '').trim();
-    const allowedCommands = ['git', 'npm', 'node', 'tsc', 'eslint', 'ls', 'cat', 'grep', 'find'];
+    const allowedCommands = [
+        // Package managers & runtimes
+        'git', 'npm', 'node', 'npx', 'yarn', 'pnpm', 'bun', 'deno',
+        // TypeScript & JavaScript tooling
+        'tsc', 'eslint', 'prettier', 'jest', 'vitest', 'mocha', 'tsx', 'ts-node',
+        // Python
+        'python', 'python3', 'pip', 'pip3', 'poetry', 'pipenv', 'uvicorn', 'flask', 'django-admin',
+        // File system & text processing (read-only + safe write ops)
+        'ls', 'cat', 'grep', 'find', 'head', 'tail', 'wc', 'sort', 'uniq', 'diff', 'sed', 'awk',
+        'cp', 'mv', 'mkdir', 'touch', 'tree', 'du', 'df',
+        // Networking & HTTP
+        'curl', 'wget',
+        // Build tools
+        'make', 'cmake', 'cargo', 'go', 'rustc', 'gcc', 'g++',
+        // Container & deployment
+        'docker', 'docker-compose',
+        // Utilities
+        'echo', 'env', 'which', 'whoami', 'pwd', 'date', 'tar', 'gzip', 'gunzip', 'zip', 'unzip',
+        'xargs', 'basename', 'dirname', 'realpath', 'readlink', 'stat', 'file',
+        // Database clients
+        'psql', 'mysql', 'sqlite3', 'mongosh', 'redis-cli',
+        // Process management
+        'kill', 'lsof', 'ps',
+    ];
     return allowedCommands.includes(c);
 }
 

--- a/api/src/tools/handlers.ts
+++ b/api/src/tools/handlers.ts
@@ -28,12 +28,46 @@ export async function handleShellCommand(
     logs.push(`exec: ${command} ${args.join(' ')} (cwd=${validCwd})`);
 
     return new Promise((resolve) => {
-        const allowedCommands = ['git', 'npm', 'node', 'tsc', 'eslint', 'ls', 'cat', 'grep', 'find', 'npx', 'yarn', 'pnpm'];
+        // Expanded command whitelist for advanced software engineering capabilities
+        const allowedCommands = [
+            // Package managers & runtimes
+            'git', 'npm', 'node', 'npx', 'yarn', 'pnpm', 'bun', 'deno',
+            // TypeScript & JavaScript tooling
+            'tsc', 'eslint', 'prettier', 'jest', 'vitest', 'mocha', 'tsx', 'ts-node',
+            // Python
+            'python', 'python3', 'pip', 'pip3', 'poetry', 'pipenv', 'uvicorn', 'flask', 'django-admin',
+            // File system & text processing
+            'ls', 'cat', 'grep', 'find', 'head', 'tail', 'wc', 'sort', 'uniq', 'diff', 'sed', 'awk',
+            'cp', 'mv', 'mkdir', 'rm', 'touch', 'chmod', 'tree', 'du', 'df',
+            // Networking & HTTP
+            'curl', 'wget',
+            // Build tools
+            'make', 'cmake', 'cargo', 'go', 'rustc', 'gcc', 'g++',
+            // Container & deployment
+            'docker', 'docker-compose',
+            // Utilities
+            'echo', 'env', 'which', 'whoami', 'pwd', 'date', 'tar', 'gzip', 'gunzip', 'zip', 'unzip',
+            'xargs', 'basename', 'dirname', 'realpath', 'readlink', 'stat', 'file',
+            // Database clients
+            'psql', 'mysql', 'sqlite3', 'mongosh', 'redis-cli',
+            // Process management
+            'kill', 'lsof', 'ps',
+        ];
+
+        // Security: Block dangerous system commands but allow engineering tools
+        const blockedCommands = ['sudo', 'su', 'passwd', 'chown', 'chroot', 'mount', 'umount',
+            'fdisk', 'mkfs', 'dd', 'shutdown', 'reboot', 'halt', 'poweroff',
+            'iptables', 'systemctl', 'service', 'useradd', 'userdel', 'groupadd'];
+
+        if (blockedCommands.includes(command)) {
+            console.warn(`[Security] Blocked dangerous system command: ${command}`);
+            resolve({ ok: false, error: 'command_blocked_for_security', logs });
+            return;
+        }
 
         if (!allowedCommands.includes(command)) {
-            console.warn(`[Security] Blocked potentially unsafe command: ${command}`);
-            resolve({ ok: false, error: 'command_not_allowed', logs });
-            return;
+            // Log warning but still allow - the blocked list above catches truly dangerous commands
+            console.warn(`[Security] Command not in whitelist but not blocked: ${command}. Allowing with caution.`);
         }
 
         const child = spawn(command, args, { cwd: validCwd, shell: false });

--- a/api/src/tools/handlers.ts
+++ b/api/src/tools/handlers.ts
@@ -38,7 +38,7 @@ export async function handleShellCommand(
             'python', 'python3', 'pip', 'pip3', 'poetry', 'pipenv', 'uvicorn', 'flask', 'django-admin',
             // File system & text processing
             'ls', 'cat', 'grep', 'find', 'head', 'tail', 'wc', 'sort', 'uniq', 'diff', 'sed', 'awk',
-            'cp', 'mv', 'mkdir', 'rm', 'touch', 'chmod', 'tree', 'du', 'df',
+            'cp', 'mv', 'mkdir', 'touch', 'tree', 'du', 'df',
             // Networking & HTTP
             'curl', 'wget',
             // Build tools

--- a/api/src/tools/handlers.ts
+++ b/api/src/tools/handlers.ts
@@ -66,8 +66,9 @@ export async function handleShellCommand(
         }
 
         if (!allowedCommands.includes(command)) {
-            // Log warning but still allow - the blocked list above catches truly dangerous commands
-            console.warn(`[Security] Command not in whitelist but not blocked: ${command}. Allowing with caution.`);
+            console.warn(`[Security] Blocked command not in whitelist: ${command}`);
+            resolve({ ok: false, error: 'command_not_allowed', logs });
+            return;
         }
 
         const child = spawn(command, args, { cwd: validCwd, shell: false });


### PR DESCRIPTION
# feat: upgrade Joe agent to advanced engineering mode (Devin-style)

## Summary

Overhauls Joe's agent core to behave more like an autonomous software engineering agent by making changes across 4 files:

1. **Agent Loop (`AgentLoopService.ts`)**: Increased `MAX_STEPS` from 50→200 (perpetual) / 10→50 (chat). Added smart context summarization when conversation exceeds 30 messages (with deduplication to avoid repeating the user goal). Circuit breaker now uses `continue` instead of `break` to let the LLM attempt recovery after failures. Added tool execution history tracking with recovery hints. All `continue` paths properly update Run status and save ToolExecution records to prevent orphaned DB records.

2. **Shell Access (`handlers.ts` + `SystemTools.ts`)**: Expanded command whitelist from 9-12 commands to ~60 commands in **both** `isAllowedLocalCommand` (the primary gate for `shell_execute`) and `handleShellCommand` (the execution layer). Added an explicit blocklist for dangerous system-admin commands (`sudo`, `su`, `shutdown`, etc.). Dangerous filesystem commands (`rm`, `chmod`) are intentionally excluded. Commands not in the whitelist are still blocked.

3. **LLM Tool Selection (`llm.ts`)**: Removed ~250 lines of hardcoded regex routing (browser patterns, search patterns, file patterns, code generation patterns, website pipeline routing) and replaced with an LLM-first approach — only explicit `https://` URL opens are still regex-handled as a fast path. Tool visibility limits increased from 56-96 to 96-128. System prompt expanded with detailed error recovery table and Devin-style engineering methodology patterns.

## Review & Testing Checklist for Human

- [ ] **Behavioral regression (llm.ts:1463-1510)**: All regex-based routing for search, file read, file list, code generation, and `website_full_pipeline` has been removed. These flows now depend entirely on the LLM selecting the correct tool from the catalog. Test that commands like "ابحث عن...", "اقرأ ملف...", "ابني تطبيق..." still work correctly and don't just produce an `echo` response. **This is the highest-risk change.**
- [ ] **Runaway loop / API cost risk (AgentLoopService.ts)**: The circuit breaker now uses `continue` instead of `break` in 3 places. Combined with MAX_STEPS=200 and increased retry thresholds (5-8), confirm the agent doesn't burn excessive API credits when genuinely stuck on an impossible task. Consider whether a hard budget or token cap is needed.
- [ ] **Dual whitelist sync (SystemTools.ts + handlers.ts)**: `isAllowedLocalCommand` and `handleShellCommand` now have separate but matching whitelists. These must be kept in sync manually — if they diverge, commands will silently fail at one layer or the other. Consider extracting to a shared constant.
- [ ] **Context summarization (AgentLoopService.ts:197-221)**: The summarization picks the first `user` message as the "goal" and truncates older messages to 150 chars. While a duplicate-goal bug was fixed, the approach is still naive — verify it doesn't lose critical context in multi-turn conversations where the user refines their goal in later messages.
- [ ] **No type checking**: Build was verified with `esbuild` (bundling only). No `tsc --noEmit` or runtime tests were executed. Type errors may exist.

**Recommended test plan**: Run Joe in agent mode with several real tasks — a file search (Arabic), a web search, a code generation request, a `shell_execute` with newly-whitelisted commands (e.g. `curl`, `python3`, `docker`), and a multi-step debugging task — and verify tool selection, error recovery, and loop termination all behave correctly.

### Notes
- Build verified with `esbuild` (bundling only, no type checking)
- No runtime or integration tests were executed
- Requested by @yasoo2
- [Link to Devin Session](https://app.devin.ai/sessions/6ff05e7aa417481e9a53265cf497b7bc)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yasoo2/xelitesolutions/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
