### PR TITLE
fix: remove spaces in API URLs and auth headers in DeploymentsPage

### DIFF
--- a/web/src/pages/admin/DeploymentsPage.tsx
+++ b/web/src/pages/admin/DeploymentsPage.tsx
@@ -54,12 +54,14 @@ export default function DeploymentsPage() {
     // Auto-deploy poller status
     const [autoDeployStatus, setAutoDeployStatus] = useState<{
         pollerActive: boolean;
+        pollerEnabled: boolean;
         pollCount: number;
         lastPollTime: string | null;
         lastPollError: string | null;
         lastLocalCommit: string | null;
         lastRemoteCommit: string | null;
         isDeploying: boolean;
+        intervalMs: number;
     } | null>(null);
 
     const token = localStorage.getItem('token') || '';
@@ -79,9 +81,9 @@ export default function DeploymentsPage() {
     const fetchAll = async () => {
         try {
             const [depRes, conRes, notifRes] = await Promise.all([
-                fetch(`${API_URL} /admin/deployments`, { headers: { Authorization: `Bearer ${token} ` } }),
-                fetch(`${API_URL} /admin/system / containers`, { headers: { Authorization: `Bearer ${token} ` } }),
-                fetch(`${API_URL} /admin/settings / notifications`, { headers: { Authorization: `Bearer ${token} ` } })
+                fetch(`${API_URL}/admin/deployments`, { headers: { Authorization: `Bearer ${token}` } }),
+                fetch(`${API_URL}/admin/system/containers`, { headers: { Authorization: `Bearer ${token}` } }),
+                fetch(`${API_URL}/admin/settings/notifications`, { headers: { Authorization: `Bearer ${token}` } })
             ]);
             if (depRes.ok) setDeployments(await depRes.json());
             if (conRes.ok) setContainers(await conRes.json());


### PR DESCRIPTION
## Summary

The `fetchAll` function in `DeploymentsPage.tsx` had spaces injected into all three API URL template literals and the Authorization header, causing every fetch call to fail with 404s:

| Before (broken) | After (fixed) |
|---|---|
| `${API_URL} /admin/deployments` | `${API_URL}/admin/deployments` |
| `${API_URL} /admin/system / containers` | `${API_URL}/admin/system/containers` |
| `${API_URL} /admin/settings / notifications` | `${API_URL}/admin/settings/notifications` |
| `Bearer ${token} ` (trailing space) | `Bearer ${token}` |

This caused the Deployment Control Center page to appear empty — no deployment history, no container fleet status, and no notification settings would load.

Also aligned the `autoDeployStatus` TypeScript interface with the backend's actual `getAutoDeployStatus()` response by adding `pollerEnabled` and `intervalMs`.

## Review & Testing Checklist for Human

- [ ] Open the Deployment Control Center (`/admin/deployments`) and verify that **deployment history**, **container fleet status**, and **notification settings** all load correctly
- [ ] Trigger a manual deploy from the UI and confirm live logs stream into the log modal via WebSocket
- [ ] Verify the Auto-Deploy status card shows real-time poller heartbeats (poll count, last poll time, commit hashes)

### Notes
- The fix was not tested against a running instance — only verified via TypeScript type-checking (`tsc --noEmit` passed clean). Manual verification in the deployed environment is recommended.
- Requested by: @yasoo2
- [Link to Devin Session](https://app.devin.ai/sessions/2e6a678fb77e496288a68b151fc5f411)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yasoo2/xelitesolutions/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
