### PR TITLE
fix: auto-deploy logging — WS broadcast, deploy failure on log files, UI state bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,12 @@ web/.env.local
 
 # logs
 *.log
+*.log.gz
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+api/logs/
+logs/
 
 # misc
 .DS_Store

--- a/api/src/services/DeployManager.ts
+++ b/api/src/services/DeployManager.ts
@@ -161,6 +161,8 @@ export class DeployManager {
             } else {
                 // Ensure no local modifications block the pull
                 await this.runCommand('git', ['checkout', '.'], id, 30000);
+                // Clean untracked log files that block merge (rotated .log.gz files)
+                await this.runCommand('git', ['clean', '-fd', 'api/logs/'], id, 10000);
                 await this.runCommand('git', ['pull', 'origin', 'main'], id, 60000);
             }
 

--- a/api/src/ws.ts
+++ b/api/src/ws.ts
@@ -316,7 +316,7 @@ export function broadcast(
       if (!authBypass) {
         if (targetUserId === 'SUPER_ADMIN_ROLE') {
           const clientRole = (client as any).role;
-          if (clientRole !== 'SUPER_ADMIN') return;
+          if (clientRole !== 'SUPER_ADMIN' && clientRole !== 'OWNER') return;
         } else if (targetUserId) {
           const clientUserId = trimId((client as any).userId);
           if (!clientUserId || clientUserId !== targetUserId) {

--- a/web/src/pages/admin/SystemManagement.tsx
+++ b/web/src/pages/admin/SystemManagement.tsx
@@ -100,6 +100,7 @@ export default function SystemManagement() {
         lastLocalCommit: string | null;
         lastRemoteCommit: string | null;
         isDeploying: boolean;
+        intervalMs: number;
     } | null>(null);
 
     // ═══════════════════════════════════════════════
@@ -238,8 +239,7 @@ export default function SystemManagement() {
                 }
             }
         } catch (e) { console.error(e); }
-        setIsDeploying(true); // Keep it true for better feedback during log streaming
-        setTimeout(() => setIsDeploying(false), 2000); // Temporary guard
+        setTimeout(() => setIsDeploying(false), 2000);
     };
 
     const handleClearHistory = async () => {


### PR DESCRIPTION
## Summary

Five fixes for the auto-deploy logging system, addressing both the deploy pipeline failure and real-time log delivery:

1. **WebSocket broadcast now includes OWNER role** (`api/src/ws.ts`): The `broadcast()` function only sent admin events (`admin:deploy_log`, `admin:autodeploy_status`, `admin:autodeploy_heartbeat`, etc.) to clients with `SUPER_ADMIN` role. However, the HTTP middleware `requireSuperAdmin` already grants access to both `SUPER_ADMIN` and `OWNER` roles. This mismatch meant OWNER users could access the admin REST API but received **zero real-time WebSocket updates** — no live deploy logs, no auto-deploy heartbeats, no status changes.

2. **Add missing `intervalMs` to autoDeployStatus type** (`web/src/pages/admin/SystemManagement.tsx`): The backend's `getAutoDeployStatus()` returns `intervalMs` but the frontend type didn't include it. Aligns the TypeScript interface with the actual API response.

3. **Fix `handleDeploy` double-setting `isDeploying=true`** (`web/src/pages/admin/SystemManagement.tsx`): `setIsDeploying(true)` was called both at the start of the function AND after the try/catch block (unconditionally, even on error). The second call was redundant and the comment ("Keep it true for better feedback") was misleading since the state was already `true`. Removed the redundant call; the `setTimeout` reset after 2s remains.

4. **Fix deploy failure caused by untracked `.log.gz` files** (`.gitignore` + `api/src/services/DeployManager.ts`): Winston's `DailyRotateFile` transport creates rotated `.log.gz` files in `api/logs/`. These were **not in `.gitignore`**, so `git pull origin main` during auto-deploy failed with:
   ```
   error: The following untracked working tree files would be overwritten by merge:
       api/logs/application-2026-03-13-03.log.gz
       api/logs/application-2026-03-13-04.log.gz
   Aborting
   ```
   Added `*.log.gz`, `api/logs/`, and `logs/` to `.gitignore`.

5. **Clean log directory before git pull in deploy process** (`api/src/services/DeployManager.ts`): Added `git clean -fd api/logs/` step before `git pull origin main` to remove untracked log files that would block the merge. This makes the deploy resilient even if `.gitignore` changes haven't propagated yet.

## Review & Testing Checklist for Human

- [ ] **Verify `git clean -fd api/logs/` is acceptable** — during each deployment, rotated log files in `api/logs/` will be deleted. Confirm this is fine since deployment logs are also stored in MongoDB via the `Deployment` model. If historical Winston file logs need to be preserved across deploys, this step would need adjustment.
- [ ] **Verify OWNER role should receive all admin WebSocket events** — this is a permission expansion. Confirm that `OWNER` users should see real-time deploy logs, auto-deploy heartbeats, and status broadcasts. Check `api/src/middleware/auth.ts` lines 73-74 for the existing OWNER allowance on HTTP routes.
- [ ] **Test deploy button behavior on `/super-admin`** — after triggering a manual deploy, verify the deploy button disables properly and re-enables after ~2 seconds.
- [ ] **Test real-time log streaming as an OWNER-role user** — connect to the admin panel as a user with `OWNER` role, trigger a deployment, and confirm deploy logs appear in real-time via WebSocket (not just via polling).
- [ ] **Trigger a test deployment after merging** — confirm that `git pull origin main` no longer fails due to untracked `.log.gz` files in `api/logs/`.

### Notes

- These changes cannot be fully end-to-end tested without the production backend (MongoDB, Docker, WebSocket server). TypeScript checks pass cleanly for both `api/` and `web/`.
- Fix #4 directly addresses the deploy failure log the user reported: the `.log.gz` files were blocking `git merge` during auto-deploy.
- Link to Devin Session: https://app.devin.ai/sessions/2e6a678fb77e496288a68b151fc5f411
- Requested by: @yasoo2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yasoo2/xelitesolutions/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
